### PR TITLE
Create a new Builder instance for each token generator call

### DIFF
--- a/src/Firebase/Auth/Token/Generator.php
+++ b/src/Firebase/Auth/Token/Generator.php
@@ -20,11 +20,6 @@ final class Generator implements Domain\Generator
     private $privateKey;
 
     /**
-     * @var Builder
-     */
-    private $builder;
-
-    /**
      * @var Signer
      */
     private $signer;
@@ -40,8 +35,6 @@ final class Generator implements Domain\Generator
     ) {
         $this->clientEmail = $clientEmail;
         $this->privateKey = $privateKey;
-
-        $this->builder = $this->createBuilder();
         $this->signer = $signer ?: new Sha256();
     }
 
@@ -58,22 +51,24 @@ final class Generator implements Domain\Generator
      */
     public function createCustomToken($uid, array $claims = [], \DateTimeInterface $expiresAt = null): Token
     {
+        $builder = $this->createBuilder();
+
         if (count($claims)) {
-            $this->builder->set('claims', $claims);
+            $builder->set('claims', $claims);
         }
 
-        $this->builder->set('uid', (string) $uid);
+        $builder->set('uid', (string) $uid);
 
         $now = time();
         $expiration = $expiresAt ? $expiresAt->getTimestamp() : $now + (60 * 60);
 
-        $token = $this->builder
+        $token = $builder
             ->setIssuedAt($now)
             ->setExpiration($expiration)
             ->sign($this->signer, $this->privateKey)
             ->getToken();
 
-        $this->builder->unsign();
+        $builder->unsign();
 
         return $token;
     }

--- a/tests/Firebase/Auth/Token/GeneratorTest.php
+++ b/tests/Firebase/Auth/Token/GeneratorTest.php
@@ -47,4 +47,13 @@ class GeneratorTest extends TestCase
 
         $this->assertTrue($noExceptionWasThrown = true);
     }
+
+    public function testDontCarryStateBetweenCalls()
+    {
+        $token1 = $this->generator->createCustomToken('first', ['admin' => true]);
+        $token2 = $this->generator->createCustomToken('second');
+
+        $this->assertSame(['admin' => true], $token1->getClaim('claims'));
+        $this->assertSame([], $token2->getClaim('claims', []));
+    }
 }


### PR DESCRIPTION
Just noticed that the custom token generator is carrying state between calls:

```php
$auth->createCustomToken($uid1, ['admin' => true]);
$auth->createCustomToken($uid2, []); // Here uid2 received the admin=true claim as well
```