### PR TITLE
Signing checking constraint not adding for non emulated environments

### DIFF
--- a/src/JWT/Action/VerifyIdToken/WithLcobucciJWT.php
+++ b/src/JWT/Action/VerifyIdToken/WithLcobucciJWT.php
@@ -83,7 +83,7 @@ final class WithLcobucciJWT implements Handler
             new PermittedFor($this->projectId),
         ];
 
-        if ($key !== '' && $this->isRunOnEmulator) {
+        if ($key !== '' && !$this->isRunOnEmulator) {
             $constraints[] = new SignedWith($this->signer, InMemory::plainText($key));
         }
 


### PR DESCRIPTION
# Description
Signing constraint not being added on non emulated environments causing every jwt passed is valid even when signing verification fails