### PR TITLE
Cache verifier key values instead of `Keys` objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 * Dropped support for PHP <8.3
+* Changed the verifier key cache to store key values instead of `Keys` objects
 
 ## 5.3.0 - 2025-09-12
 

--- a/src/JWT/Action/FetchGooglePublicKeys/WithPsr6Cache.php
+++ b/src/JWT/Action/FetchGooglePublicKeys/WithPsr6Cache.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Kreait\Firebase\JWT\Action\FetchGooglePublicKeys;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use Kreait\Firebase\JWT\Action\FetchGooglePublicKeys;
 use Kreait\Firebase\JWT\Contract\Expirable;
 use Kreait\Firebase\JWT\Contract\Keys;
 use Kreait\Firebase\JWT\Error\FetchingGooglePublicKeysFailed;
+use Kreait\Firebase\JWT\Keys\ExpiringKeys;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Clock\ClockInterface;
 
@@ -16,6 +19,8 @@ use Psr\Clock\ClockInterface;
  */
 final readonly class WithPsr6Cache implements Handler
 {
+    private const int CACHE_PAYLOAD_VERSION = 1;
+
     public function __construct(
         private Handler $handler,
         private CacheItemPoolInterface $cache,
@@ -31,12 +36,11 @@ final readonly class WithPsr6Cache implements Handler
         /** @noinspection PhpUnhandledExceptionInspection */
         $cacheItem = $this->cache->getItem($cacheKey);
 
-        /** @var Keys|Expirable|null $keys */
-        $keys = $cacheItem->get();
+        $keys = $this->keysFromCachedValue($cacheItem->get());
 
         // We deliberately don't care if the cache item is expired here, as long as the keys
         // themselves are not expired
-        if ($keys instanceof Keys && $keys instanceof Expirable && !$keys->isExpiredAt($now)) {
+        if ($keys instanceof Expirable && !$keys->isExpiredAt($now)) {
             return $keys;
         }
 
@@ -62,7 +66,7 @@ final readonly class WithPsr6Cache implements Handler
             throw FetchingGooglePublicKeysFailed::because($reason, $e->getCode(), $e);
         }
 
-        $cacheItem->set($keys);
+        $cacheItem->set($this->cachedValueFromKeys($keys, $action));
 
         if ($keys instanceof Expirable) {
             $cacheItem->expiresAt($keys->expiresAt());
@@ -73,5 +77,85 @@ final readonly class WithPsr6Cache implements Handler
         $this->cache->save($cacheItem);
 
         return $keys;
+    }
+
+    private function keysFromCachedValue(mixed $cached): ?Keys
+    {
+        if ($cached === null) {
+            return null;
+        }
+
+        // Keep accepting object values written by previous library versions.
+        if ($cached instanceof Keys) {
+            return $cached;
+        }
+
+        if (!is_array($cached)) {
+            return null;
+        }
+
+        // Only restore payloads written by this version.
+        if (($cached['version'] ?? null) !== self::CACHE_PAYLOAD_VERSION) {
+            return null;
+        }
+
+        $values = $cached['values'] ?? null;
+        $expiresAt = $cached['expiresAt'] ?? null;
+
+        if (!is_string($expiresAt)) {
+            return null;
+        }
+
+        $values = $this->keyValuesFromCachedValue($values);
+
+        if ($values === null) {
+            return null;
+        }
+
+        try {
+            $expirationTime = new DateTimeImmutable($expiresAt);
+        } catch (\Exception) {
+            return null;
+        }
+
+        return ExpiringKeys::withValuesAndExpirationTime($values, $expirationTime);
+    }
+
+    /**
+     * @return array<non-empty-string, non-empty-string>|null
+     */
+    private function keyValuesFromCachedValue(mixed $value): ?array
+    {
+        if (!is_array($value)) {
+            return null;
+        }
+
+        foreach ($value as $keyId => $key) {
+            if (!is_string($keyId) || $keyId === '' || !is_string($key) || $key === '') {
+                return null;
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{
+     *     version: non-negative-int,
+     *     values: array<non-empty-string, non-empty-string>,
+     *     expiresAt: non-empty-string
+     * }
+     */
+    private function cachedValueFromKeys(Keys $keys, FetchGooglePublicKeys $action): array
+    {
+        $expiresAt = $keys instanceof Expirable
+            ? $keys->expiresAt()
+            : $this->clock->now()->add($action->getFallbackCacheDuration()->value());
+
+        return [
+            'version' => self::CACHE_PAYLOAD_VERSION,
+            'values' => $keys->all(),
+            'expiresAt' => $expiresAt->format(DateTimeInterface::ATOM),
+        ];
     }
 }

--- a/tests/JWT/Action/FetchGooglePublicKeys/WithPsr6CacheTest.php
+++ b/tests/JWT/Action/FetchGooglePublicKeys/WithPsr6CacheTest.php
@@ -7,6 +7,7 @@ namespace Kreait\Firebase\JWT\Tests\Action\FetchGooglePublicKeys;
 use Beste\Cache\InMemoryCache;
 use Kreait\Firebase\JWT\Action\FetchGooglePublicKeys\Handler;
 use Kreait\Firebase\JWT\Action\FetchGooglePublicKeys\WithPsr6Cache;
+use Kreait\Firebase\JWT\Contract\Keys;
 use Kreait\Firebase\JWT\Error\FetchingGooglePublicKeysFailed;
 use Kreait\Firebase\JWT\Keys\ExpiringKeys;
 use Kreait\Firebase\JWT\Keys\StaticKeys;
@@ -46,7 +47,13 @@ final class WithPsr6CacheTest extends TestCase
         $this->inner->expects($this->once())->method('handle')->willReturn($this->expiringKeys);
 
         $this->assertSame($this->expiringKeys, $this->createHandler()->handle($this->action));
-        $this->assertSame($this->expiringKeys, $this->cachedValue());
+
+        $payload = $this->cachedValue();
+
+        $this->assertNotInstanceOf(Keys::class, $payload);
+        $this->assertIsArray($payload);
+        $this->assertSame(['ir' => 'relevant'], $payload['values'] ?? null);
+        $this->assertSame($this->expiringKeys->expiresAt()->format(DATE_ATOM), $payload['expiresAt'] ?? null);
     }
 
     public function testItCachesNonExpiringKeysWithFallbackExpiration(): void
@@ -54,7 +61,13 @@ final class WithPsr6CacheTest extends TestCase
         $this->inner->expects($this->once())->method('handle')->willReturn($this->nonExpiringKeys);
 
         $this->assertSame($this->nonExpiringKeys, $this->createHandler()->handle($this->action));
-        $this->assertSame($this->nonExpiringKeys, $this->cachedValue());
+
+        $payload = $this->cachedValue();
+
+        $this->assertNotInstanceOf(Keys::class, $payload);
+        $this->assertIsArray($payload);
+        $this->assertSame(['ir' => 'relevant'], $payload['values'] ?? null);
+        $this->assertSame($this->clock->now()->modify('+1 hour')->format(DATE_ATOM), $payload['expiresAt'] ?? null);
 
         $this->clock->setTo($this->clock->now()->modify('+59 minutes'));
         $this->assertTrue($this->cache->getItem($this->cacheKey())->isHit());
@@ -72,6 +85,22 @@ final class WithPsr6CacheTest extends TestCase
         $this->assertSame($this->expiringKeys, $this->createHandler()->handle($this->action));
     }
 
+    public function testItReturnsCachedNonExpiredKeysFromArrayPayload(): void
+    {
+        $this->storeCachedValue([
+            'version' => 1,
+            'values' => ['ir' => 'relevant'],
+            'expiresAt' => $this->expiringKeys->expiresAt()->format(DATE_ATOM),
+        ]);
+        $this->inner->expects($this->never())->method($this->anything());
+
+        $keys = $this->createHandler()->handle($this->action);
+
+        $this->assertInstanceOf(ExpiringKeys::class, $keys);
+        $this->assertSame(['ir' => 'relevant'], $keys->all());
+        $this->assertEquals($this->expiringKeys->expiresAt(), $keys->expiresAt());
+    }
+
     public function testItReturnsCachedNonExpiringKeys(): void
     {
         $this->storeCachedValue($this->nonExpiringKeys);
@@ -85,6 +114,18 @@ final class WithPsr6CacheTest extends TestCase
     {
         $this->storeCachedValue($this->expiredKeys);
 
+        $this->inner->expects($this->once())->method('handle')->willReturn($this->expiringKeys);
+
+        $this->assertSame($this->expiringKeys, $this->createHandler()->handle($this->action));
+    }
+
+    public function testItRefreshesExpiredKeysFromArrayPayload(): void
+    {
+        $this->storeCachedValue([
+            'version' => 1,
+            'values' => ['ir' => 'relevant'],
+            'expiresAt' => $this->expiredKeys->expiresAt()->format(DATE_ATOM),
+        ]);
         $this->inner->expects($this->once())->method('handle')->willReturn($this->expiringKeys);
 
         $this->assertSame($this->expiringKeys, $this->createHandler()->handle($this->action));


### PR DESCRIPTION
Store the string values from `Keys::all()` with expiration metadata instead of full `Keys` objects

:octocat: 