### PR TITLE
Add support for Guzzle 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Added support for Guzzle 8
+
 ## 5.4.0 - 2026-07-18
 
 * Dropped support for PHP <8.3

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-openssl": "*",
         "beste/clock": "^3.0",
         "fig/http-message-util": "^1.1.5",
-        "guzzlehttp/guzzle": "^7.8",
+        "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
         "lcobucci/jwt": "^5.2",
         "psr/cache": "^1.0|^2.0|^3.0"
     },


### PR DESCRIPTION
This widens the `guzzlehttp/guzzle` constraint to `^7.8.2 || ^8.0` so the package installs on Guzzle 8 alongside Guzzle 7. Token verification only touches Guzzle through its high-level client and PSR-7 messages and catches `GuzzleHttp\Exception\GuzzleException`, none of which changed between the two majors, so no code changes are needed. Guzzle 8 is already released and this package has no other dependency that blocks it, so it can be merged and released on its own. Doing so unblocks the Guzzle 8 work in beste/firebase-php#1111, which depends on a release of `kreait/firebase-tokens` that allows Guzzle 8.
